### PR TITLE
Added ability to handle deep nested objects

### DIFF
--- a/fields/types/obj/ObjType.js
+++ b/fields/types/obj/ObjType.js
@@ -186,18 +186,37 @@ obj.prototype.updateItem = function (item, data, files, callback) {
 	}
 
 	var field = this;
-	var value = {};
 
-	field.fieldsArray.forEach(function (nestedField) {
-		var nestedValue = nestedField.getValueFromData(data[field.path]);
-		value[nestedField.path] = nestedValue;
-	});
+	// Recursively get nested fields
+	var value = getDataFromObject(data, field);
+
+
 
 	item.set(field.path, value);
 
 	callback();
 
 };
+
+function getDataFromObject(data, field) {
+
+	let fullObject = {};
+
+	if (field.fieldsArray) {
+		field.fieldsArray.forEach(function (nestedField) {
+			if (nestedField.fieldsArray) {
+				fullObject[nestedField.path] = getDataFromObject(data, nestedField)
+			} else {
+				fullObject[nestedField.path] = nestedField.getValueFromData(data[field.path] || data);
+			}
+		})
+	} else {
+		fullObject[field.path] = field.getValueFromData(data[nestedField.path] || data);
+	}
+
+	return fullObject;
+
+}
 
 /* Export Field Type */
 module.exports = obj;


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Added the ability to handle deeply nested objects

## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

